### PR TITLE
Add strong reference to metrics to avoid being GCed

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -21,7 +21,7 @@ scrape_configs:
           - localhost:9090
   - job_name: trustyai-service
     metrics_path: '/q/metrics'
-    scrape_interval: 2s
+    scrape_interval: 5s
     static_configs:
       - targets:
           - trustyai:8080

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/AbstractMetricsEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/AbstractMetricsEndpoint.java
@@ -1,22 +1,11 @@
 package org.kie.trustyai.service.endpoints.metrics;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
-
 public abstract class AbstractMetricsEndpoint {
-    private final MeterRegistry registry;
 
-    AbstractMetricsEndpoint(MeterRegistry registry) {
-        this.registry = registry;
-    }
+    AbstractMetricsEndpoint() {
 
-    public MeterRegistry getRegistry() {
-        return registry;
     }
 
     public abstract String getMetricName();
-
-    public void gauge(Iterable<Tag> tags, double value) {
-        this.getRegistry().gauge("trustyai_" + getMetricName(), tags, value);
-    }
+    
 }

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -14,9 +14,6 @@ import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
 import io.quarkus.scheduler.Scheduled;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -34,6 +31,7 @@ import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceReq
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceResponse;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceScheduledRequests;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceScheduledResponse;
+import org.kie.trustyai.service.prometheus.PrometheusPublisher;
 
 @Path("/metrics/spd")
 public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEndpoint {
@@ -41,6 +39,10 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
     private static final Logger LOG = Logger.getLogger(GroupStatisticalParityDifferenceEndpoint.class);
     @Inject
     MinioReader dataReader;
+
+    @Inject
+    PrometheusPublisher publisher;
+
     @ConfigProperty(name = "SPD_THRESHOLD_LOWER", defaultValue = "-0.1")
     double thresholdLower;
     @ConfigProperty(name = "SPD_THRESHOLD_UPPER", defaultValue = "0.1")
@@ -51,13 +53,28 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
     @Inject
     GroupStatisticalParityDifferenceScheduledRequests schedule;
 
-    GroupStatisticalParityDifferenceEndpoint(MeterRegistry registry) {
-        super(registry);
+    GroupStatisticalParityDifferenceEndpoint() {
+        super();
     }
 
     @Override
     public String getMetricName() {
         return "spd";
+    }
+
+    public double calculate(Dataframe dataframe, GroupStatisticalParityDifferenceRequest request) {
+        final int protectedIndex = dataframe.getColumnNames().indexOf(request.getProtectedAttribute());
+
+        final Value privilegedAttr = PayloadConverter.convertToValue(request.getPrivilegedAttribute());
+
+        final Dataframe privileged = dataframe.filterByColumnValue(protectedIndex,
+                value -> value.equals(privilegedAttr));
+        final Value unprivilegedAttr = PayloadConverter.convertToValue(request.getUnprivilegedAttribute());
+        final Dataframe unprivileged = dataframe.filterByColumnValue(protectedIndex,
+                value -> value.equals(unprivilegedAttr));
+        final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
+        return FairnessMetrics.groupStatisticalParityDifference(privileged, unprivileged,
+                List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
     }
 
     @POST
@@ -67,27 +84,12 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
 
         final Dataframe df = dataReader.asDataframe();
 
-        final int protectedIndex = df.getColumnNames().indexOf(request.getProtectedAttribute());
-
-        final Value privilegedAttr = PayloadConverter.convertToValue(request.getPrivilegedAttribute());
-
-        final Dataframe privileged = df.filterByColumnValue(protectedIndex,
-                value -> value.equals(privilegedAttr));
-        final Value unprivilegedAttr = PayloadConverter.convertToValue(request.getUnprivilegedAttribute());
-        final Dataframe unprivileged = df.filterByColumnValue(protectedIndex,
-                value -> value.equals(unprivilegedAttr));
-        final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
-        final double spd = FairnessMetrics.groupStatisticalParityDifference(privileged, unprivileged,
-                List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
+        final double spd = calculate(df, request);
 
         final MetricThreshold thresholds = new MetricThreshold(thresholdLower, thresholdUpper, spd);
         final GroupStatisticalParityDifferenceResponse spdObj = new GroupStatisticalParityDifferenceResponse(spd, thresholds);
-        this.gauge(Tags.of(
-                Tag.of("model", modelName),
-                Tag.of("outcome", request.getOutcomeName()),
-                Tag.of("protected", request.getProtectedAttribute())), spd);
-        ObjectMapper mapper = new ObjectMapper();
 
+        ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(spdObj);
     }
 
@@ -115,7 +117,7 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/request")
-    public Response deleteRequest(ScheduleId request) throws JsonProcessingException {
+    public Response deleteRequest(ScheduleId request) {
 
         final UUID id = request.requestId;
 
@@ -135,28 +137,9 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
         if (!schedule.getRequests().isEmpty()) {
             schedule.getRequests().forEach((uuid, request) -> {
 
-                final int protectedIndex = df.getColumnNames().indexOf(request.getProtectedAttribute());
+                final double spd = calculate(df, request);
 
-                final Value privilegedAttr = PayloadConverter.convertToValue(request.getPrivilegedAttribute());
-
-                final Dataframe privileged = df.filterByColumnValue(protectedIndex,
-                        value -> value.equals(privilegedAttr));
-
-                final Value unprivilegedAttr = PayloadConverter.convertToValue(request.getUnprivilegedAttribute());
-
-                final Dataframe unprivileged = df.filterByColumnValue(protectedIndex,
-                        value -> value.equals(unprivilegedAttr));
-
-                final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
-
-                final double spd = FairnessMetrics.groupStatisticalParityDifference(privileged, unprivileged,
-                        List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
-
-                this.gauge(Tags.of(
-                        Tag.of("model", modelName),
-                        Tag.of("outcome", request.getOutcomeName()),
-                        Tag.of("protected", request.getProtectedAttribute())), spd);
-                LOG.info("Scheduled request for SPD id=" + uuid + ", value=" + spd);
+                publisher.gaugeSPD(request, modelName, uuid, spd);
             });
         }
     }

--- a/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
+++ b/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
@@ -1,0 +1,69 @@
+package org.kie.trustyai.service.prometheus;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.inject.Singleton;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.jboss.logging.Logger;
+import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
+
+@Singleton
+public class PrometheusPublisher {
+    private static final Logger LOG = Logger.getLogger(PrometheusPublisher.class);
+    private final MeterRegistry registry;
+    private final Map<UUID, AtomicDouble> values;
+    private final Map<UUID, Iterable<Tag>> tags;
+
+    public PrometheusPublisher(MeterRegistry registry) {
+        this.registry = registry;
+        this.values = new HashMap<>();
+        this.tags = new HashMap<>();
+    }
+
+    private AtomicDouble getValue(UUID id) {
+        return values.get(id);
+    }
+
+    private void createOrUpdateGauge(String name, Iterable<Tag> tags, UUID id) {
+        Gauge.builder(name, new AtomicDouble(), value -> values.get(id).doubleValue())
+                .tags(tags).strongReference(true).register(registry);
+
+    }
+
+    public void gaugeSPD(GroupStatisticalParityDifferenceRequest request, String modelName, UUID id, double value) {
+
+        values.put(id, new AtomicDouble(value));
+
+        final Iterable<Tag> tags = Tags.of(
+                Tag.of("model", modelName),
+                Tag.of("outcome", request.getOutcomeName()),
+                Tag.of("protected", request.getProtectedAttribute()),
+                Tag.of("request", id.toString()));
+
+        createOrUpdateGauge("trustyai_spd", tags, id);
+
+        LOG.info("Scheduled request for SPD id=" + id + ", value=" + value);
+    }
+
+    public void gaugeDIR(GroupStatisticalParityDifferenceRequest request, String modelName, UUID id, double value) {
+
+        values.put(id, new AtomicDouble(value));
+
+        final Iterable<Tag> tags = Tags.of(
+                Tag.of("model", modelName),
+                Tag.of("outcome", request.getOutcomeName()),
+                Tag.of("protected", request.getProtectedAttribute()),
+                Tag.of("request", id.toString()));
+
+        createOrUpdateGauge("trustyai_dir", tags, id);
+
+        LOG.info("Scheduled request for DIR id=" + id + ", value=" + value);
+    }
+}

--- a/src/requests/test.http
+++ b/src/requests/test.http
@@ -30,6 +30,17 @@ Content-Type: application/json
 }
 
 ###
+POST http://{{host}}:8080/metrics/dir
+Content-Type: application/json
+
+{
+  "protectedAttribute": "gender",
+  "favorableOutcome": 1,
+  "outcomeName": "income",
+  "privilegedAttribute": 1,
+  "unprivilegedAttribute": 0
+}
+###
 POST http://{{host}}:8080/metrics/dir/request
 Content-Type: application/json
 
@@ -46,7 +57,7 @@ DELETE http://{{host}}:8080/metrics/dir/request
 Content-Type: application/json
 
 {
-  "requestId": "8d46775b-89e7-414f-8f6c-f3ec4b3f07e7"
+  "requestId": "f3297e6f-7a24-4de0-ad2c-b8aa9a03b5a1"
 }
 
 ###


### PR DESCRIPTION
Add strong references to avoid Prometheus meters being GCed (see [Why is My Gauge Reporting NaN or Disappearing?](https://micrometer.io/docs/concepts#_why_is_my_gauge_reporting_nan_or_disappearing)).

This closes #13 .