### PR TITLE
Add exception handling for MinIO data reading and dataframe creation

### DIFF
--- a/src/main/java/org/kie/trustyai/service/data/readers/CSVReader.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/CSVReader.java
@@ -1,7 +1,6 @@
 package org.kie.trustyai.service.data.readers;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
 import org.kie.trustyai.explainability.model.Dataframe;
@@ -11,7 +10,7 @@ import org.kie.trustyai.service.data.readers.utils.CSVUtils;
 
 public class CSVReader implements DataReader {
 
-    private Dataframe df;
+    private final Dataframe df;
 
     public CSVReader(String inputs, String outputs) throws IOException {
         final List<PredictionInput> predictionInputs = CSVUtils.parseInputs(inputs);
@@ -19,7 +18,8 @@ public class CSVReader implements DataReader {
         this.df = Dataframe.createFrom(predictionInputs, predictionOutputs);
     }
 
-    @Override public Dataframe asDataframe() {
+    @Override
+    public Dataframe asDataframe() {
         return this.df;
     }
 }

--- a/src/main/java/org/kie/trustyai/service/data/readers/DataReader.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/DataReader.java
@@ -1,7 +1,8 @@
 package org.kie.trustyai.service.data.readers;
 
 import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.data.readers.exceptions.DataframeCreateException;
 
 public interface DataReader {
-    Dataframe asDataframe();
+    Dataframe asDataframe() throws DataframeCreateException;
 }

--- a/src/main/java/org/kie/trustyai/service/data/readers/MinioReader.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/MinioReader.java
@@ -8,15 +8,19 @@ import java.util.List;
 
 import javax.inject.Singleton;
 
-import io.minio.GetObjectArgs;
-import io.minio.MinioClient;
-import io.minio.errors.MinioException;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.service.data.readers.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.readers.utils.CSVUtils;
+
+import io.minio.GetObjectArgs;
+import io.minio.MinioClient;
+import io.minio.StatObjectArgs;
+import io.minio.StatObjectResponse;
+import io.minio.errors.*;
 
 @Singleton
 public class MinioReader implements DataReader {
@@ -49,32 +53,62 @@ public class MinioReader implements DataReader {
                         .build();
     }
 
-    public Dataframe parseData() {
+    private StatObjectResponse getObjectStats(String bucket, String filename) throws ServerException, InsufficientDataException, ErrorResponseException, IOException, NoSuchAlgorithmException,
+            InvalidKeyException, InvalidResponseException, XmlParserException, InternalException {
+        return minioClient.statObject(
+                StatObjectArgs.builder().bucket(bucket).object(filename).build());
+    }
+
+    private StatObjectResponse isObjectAvailable(String bucketName, String filename) throws MinioException {
         try {
-            final String is = new String(minioClient.getObject(
-                    GetObjectArgs.builder()
-                            .bucket(this.bucketName)
-                            .object(this.inputFilename)
-                            .build()).readAllBytes(), StandardCharsets.UTF_8);
-            final List<PredictionInput> predictionInputs = CSVUtils.parseInputs(is);
-
-            final String os = new String(minioClient.getObject(
-                    GetObjectArgs.builder()
-                            .bucket(this.bucketName)
-                            .object(this.outputFilename)
-                            .build()).readAllBytes(), StandardCharsets.UTF_8);
-            final List<PredictionOutput> predictionOutputs = CSVUtils.parseOutputs(os);
-            return Dataframe.createFrom(predictionInputs, predictionOutputs);
-
-        } catch (MinioException e) {
-            throw new IllegalStateException(e);
-        } catch (IOException | NoSuchAlgorithmException | InvalidKeyException e) {
-            throw new RuntimeException(e);
+            return getObjectStats(bucketName, filename);
+        } catch (MinioException | IOException | NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new MinioException(e.getMessage());
         }
     }
 
+    private String readFile(String bucketName, String filename) throws MinioException, IOException, NoSuchAlgorithmException, InvalidKeyException {
+        return new String(minioClient.getObject(
+                GetObjectArgs.builder()
+                        .bucket(bucketName)
+                        .object(filename)
+                        .build())
+                .readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    public Dataframe readData() throws IOException, MinioException, NoSuchAlgorithmException, InvalidKeyException {
+
+        try {
+            isObjectAvailable(this.bucketName, this.inputFilename);
+        } catch (MinioException e) {
+            LOG.error("Input file '" + this.inputFilename + "' at bucket '" + this.bucketName + "' is not available");
+            throw new MinioException(e.getMessage());
+        }
+
+        try {
+            isObjectAvailable(this.bucketName, this.outputFilename);
+        } catch (MinioException e) {
+            LOG.error("Output file '" + this.inputFilename + "' at bucket '" + this.bucketName + "' is not available");
+            throw new MinioException(e.getMessage());
+        }
+
+        final String inputs = readFile(this.bucketName, this.inputFilename);
+        final List<PredictionInput> predictionInputs = CSVUtils.parseInputs(inputs);
+        final String outputs = readFile(this.bucketName, this.outputFilename);
+        final List<PredictionOutput> predictionOutputs = CSVUtils.parseOutputs(outputs);
+        return Dataframe.createFrom(predictionInputs, predictionOutputs);
+
+    }
+
     @Override
-    public Dataframe asDataframe() {
-        return parseData();
+    public Dataframe asDataframe() throws DataframeCreateException {
+        try {
+            return readData();
+        } catch (MinioException e) {
+            LOG.error(e.getMessage());
+            throw new DataframeCreateException(e.getMessage());
+        } catch (IOException | NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new DataframeCreateException(e.getMessage());
+        }
     }
 }

--- a/src/main/java/org/kie/trustyai/service/data/readers/RandomReader.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/RandomReader.java
@@ -4,16 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.Feature;
-import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.kie.trustyai.explainability.model.Output;
-import org.kie.trustyai.explainability.model.Prediction;
-import org.kie.trustyai.explainability.model.PredictionInput;
-import org.kie.trustyai.explainability.model.PredictionOutput;
-import org.kie.trustyai.explainability.model.SimplePrediction;
-import org.kie.trustyai.explainability.model.Type;
-import org.kie.trustyai.explainability.model.Value;
+import org.kie.trustyai.explainability.model.*;
 
 public class RandomReader implements DataReader {
 
@@ -31,8 +22,7 @@ public class RandomReader implements DataReader {
             List<Feature> features = List.of(
                     FeatureFactory.newNumericalFeature("age", random.nextInt(82) + 18),
                     FeatureFactory.newNumericalFeature("race", random.nextInt(7)),
-                    FeatureFactory.newNumericalFeature("gender", gender)
-            );
+                    FeatureFactory.newNumericalFeature("gender", gender));
             // Create biased data
             int income;
             if (gender == 0) {
@@ -41,15 +31,15 @@ public class RandomReader implements DataReader {
                 income = random.nextDouble() < 0.55 ? 1 : 0;
             }
             List<Output> output = List.of(
-                    new Output("income", Type.NUMBER, new Value(income), 1.0)
-            );
+                    new Output("income", Type.NUMBER, new Value(income), 1.0));
             final Prediction prediction = new SimplePrediction(new PredictionInput(features), new PredictionOutput(output));
             predictions.add(prediction);
         }
         return predictions;
     }
 
-    @Override public Dataframe asDataframe() {
+    @Override
+    public Dataframe asDataframe() {
         this.df.addPredictions(generateRandom());
         return this.df;
     }

--- a/src/main/java/org/kie/trustyai/service/data/readers/exceptions/DataframeCreateException.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/exceptions/DataframeCreateException.java
@@ -1,0 +1,7 @@
+package org.kie.trustyai.service.data.readers.exceptions;
+
+public class DataframeCreateException extends Exception {
+    public DataframeCreateException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/org/kie/trustyai/service/data/readers/utils/CSVUtils.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/utils/CSVUtils.java
@@ -1,26 +1,16 @@
 package org.kie.trustyai.service.data.readers.utils;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.kie.trustyai.explainability.model.Feature;
-import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.kie.trustyai.explainability.model.Output;
-import org.kie.trustyai.explainability.model.PredictionInput;
-import org.kie.trustyai.explainability.model.PredictionOutput;
-import org.kie.trustyai.explainability.model.Type;
-import org.kie.trustyai.explainability.model.Value;
-
+import org.kie.trustyai.explainability.model.*;
 
 public class CSVUtils {
 

--- a/src/main/java/org/kie/trustyai/service/endpoints/explainers/LIMEEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/explainers/LIMEEndpoint.java
@@ -8,18 +8,13 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.kie.trustyai.connectors.kserve.v2.KServeV2GRPCPredictionProvider;
 import org.kie.trustyai.explainability.local.lime.LimeExplainer;
-import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.kie.trustyai.explainability.model.Prediction;
-import org.kie.trustyai.explainability.model.PredictionInput;
-import org.kie.trustyai.explainability.model.PredictionOutput;
-import org.kie.trustyai.explainability.model.PredictionProvider;
-import org.kie.trustyai.explainability.model.SaliencyResults;
-import org.kie.trustyai.explainability.model.SimplePrediction;
+import org.kie.trustyai.explainability.model.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Path("/lime")
 public class LIMEEndpoint {
@@ -33,11 +28,11 @@ public class LIMEEndpoint {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public String lime() throws ExecutionException, InterruptedException, JsonProcessingException {
-    final PredictionInput positiveInput = new PredictionInput(List.of(
-            FeatureFactory.newNumericalFeature("x-1", 20.42),
-            FeatureFactory.newNumericalFeature("x-2", 7.5),
-            FeatureFactory.newNumericalFeature("x-3", 1.5),
-            FeatureFactory.newNumericalFeature("x-4", 235.0)));
+        final PredictionInput positiveInput = new PredictionInput(List.of(
+                FeatureFactory.newNumericalFeature("x-1", 20.42),
+                FeatureFactory.newNumericalFeature("x-2", 7.5),
+                FeatureFactory.newNumericalFeature("x-3", 1.5),
+                FeatureFactory.newNumericalFeature("x-4", 235.0)));
         final PredictionProvider provider = KServeV2GRPCPredictionProvider
                 .forTarget(target, modelName);
 
@@ -50,6 +45,5 @@ public class LIMEEndpoint {
 
         return mapper.writeValueAsString(explanation.getSaliencies());
     }
-
 
 }

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/AbstractMetricsEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/AbstractMetricsEndpoint.java
@@ -7,5 +7,5 @@ public abstract class AbstractMetricsEndpoint {
     }
 
     public abstract String getMetricName();
-    
+
 }

--- a/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
@@ -1,8 +1,9 @@
 package org.kie.trustyai.service.payloads;
 
+import org.kie.trustyai.explainability.model.Value;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
-import org.kie.trustyai.explainability.model.Value;
 
 public class PayloadConverter {
     public static Value convertToValue(JsonNode node) {

--- a/src/main/java/org/kie/trustyai/service/payloads/exceptions/DataframeCreateExceptionMapper.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/exceptions/DataframeCreateExceptionMapper.java
@@ -1,0 +1,22 @@
+package org.kie.trustyai.service.payloads.exceptions;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.kie.trustyai.service.data.readers.exceptions.DataframeCreateException;
+
+@Provider
+public class DataframeCreateExceptionMapper implements ExceptionMapper<DataframeCreateException> {
+
+    @Override
+    public Response toResponse(DataframeCreateException exception) {
+
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity("Error reading dataset: " + exception.getMessage())
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+}

--- a/src/main/java/org/kie/trustyai/service/payloads/spd/DisparateImpactRatioScheduledRequests.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/spd/DisparateImpactRatioScheduledRequests.java
@@ -1,15 +1,15 @@
 package org.kie.trustyai.service.payloads.spd;
 
-import javax.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import javax.inject.Singleton;
 
 @Singleton
 public class DisparateImpactRatioScheduledRequests {
 
     private final Map<UUID, GroupStatisticalParityDifferenceRequest> requests = new HashMap<>();
-
 
     public Map<UUID, GroupStatisticalParityDifferenceRequest> getRequests() {
         return requests;

--- a/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceScheduledRequests.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceScheduledRequests.java
@@ -1,15 +1,15 @@
 package org.kie.trustyai.service.payloads.spd;
 
-import javax.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import javax.inject.Singleton;
 
 @Singleton
 public class GroupStatisticalParityDifferenceScheduledRequests {
 
     private final Map<UUID, GroupStatisticalParityDifferenceRequest> requests = new HashMap<>();
-
 
     public Map<UUID, GroupStatisticalParityDifferenceRequest> getRequests() {
         return requests;

--- a/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceScheduledResponse.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceScheduledResponse.java
@@ -3,12 +3,10 @@ package org.kie.trustyai.service.payloads.spd;
 import java.util.Date;
 import java.util.UUID;
 
-
 public class GroupStatisticalParityDifferenceScheduledResponse {
 
     public UUID requestId;
     public Date timestamp = new Date();
-
 
     public GroupStatisticalParityDifferenceScheduledResponse(UUID uuid) {
         this.requestId = uuid;

--- a/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
+++ b/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
@@ -6,13 +6,15 @@ import java.util.UUID;
 
 import javax.inject.Singleton;
 
+import org.jboss.logging.Logger;
+import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
+
 import com.google.common.util.concurrent.AtomicDouble;
+
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
-import org.jboss.logging.Logger;
-import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
 
 @Singleton
 public class PrometheusPublisher {


### PR DESCRIPTION
Add exception handling for:

- MinIO files not found
- Map exceptions into REST endpoints
- Continue polling filenames in metrics request instead of stopping

To test, change `MINIO_*_FILENAME` in the demo's `compose.yaml` to an invalid filename.

Closes #18 .