### PR TITLE
Move schedule actions to single method

### DIFF
--- a/src/main/java/org/kie/trustyai/service/data/readers/MinioReader.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/MinioReader.java
@@ -8,6 +8,17 @@ import java.util.List;
 
 import javax.inject.Singleton;
 
+import io.minio.GetObjectArgs;
+import io.minio.MinioClient;
+import io.minio.StatObjectArgs;
+import io.minio.StatObjectResponse;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.InsufficientDataException;
+import io.minio.errors.InternalException;
+import io.minio.errors.InvalidResponseException;
+import io.minio.errors.MinioException;
+import io.minio.errors.ServerException;
+import io.minio.errors.XmlParserException;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.PredictionInput;
@@ -15,12 +26,6 @@ import org.kie.trustyai.explainability.model.PredictionOutput;
 import org.kie.trustyai.service.config.readers.MinioConfig;
 import org.kie.trustyai.service.data.readers.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.readers.utils.CSVUtils;
-
-import io.minio.GetObjectArgs;
-import io.minio.MinioClient;
-import io.minio.StatObjectArgs;
-import io.minio.StatObjectResponse;
-import io.minio.errors.*;
 
 @Singleton
 public class MinioReader implements DataReader {
@@ -39,7 +44,8 @@ public class MinioReader implements DataReader {
         this.bucketName = config.bucketName();
         this.inputFilename = config.inputFilename();
         this.outputFilename = config.outputFilename();
-        LOG.info("MinIO data location: endpoint=" + config.endpoint() + ", bucket=" + bucketName + ", input file=" + inputFilename
+        LOG.info("MinIO data location: endpoint=" + config.endpoint() + ", bucket=" + bucketName + ", input file="
+                + inputFilename
                 + ", output filename=" + outputFilename);
         this.minioClient =
                 MinioClient.builder()
@@ -48,7 +54,8 @@ public class MinioReader implements DataReader {
                         .build();
     }
 
-    private StatObjectResponse getObjectStats(String bucket, String filename) throws ServerException, InsufficientDataException, ErrorResponseException, IOException, NoSuchAlgorithmException,
+    private StatObjectResponse getObjectStats(String bucket, String filename)
+            throws ServerException, InsufficientDataException, ErrorResponseException, IOException, NoSuchAlgorithmException,
             InvalidKeyException, InvalidResponseException, XmlParserException, InternalException {
         return minioClient.statObject(
                 StatObjectArgs.builder().bucket(bucket).object(filename).build());
@@ -62,12 +69,13 @@ public class MinioReader implements DataReader {
         }
     }
 
-    private String readFile(String bucketName, String filename) throws MinioException, IOException, NoSuchAlgorithmException, InvalidKeyException {
+    private String readFile(String bucketName, String filename)
+            throws MinioException, IOException, NoSuchAlgorithmException, InvalidKeyException {
         return new String(minioClient.getObject(
-                GetObjectArgs.builder()
-                        .bucket(bucketName)
-                        .object(filename)
-                        .build())
+                        GetObjectArgs.builder()
+                                .bucket(bucketName)
+                                .object(filename)
+                                .build())
                 .readAllBytes(), StandardCharsets.UTF_8);
     }
 

--- a/src/main/java/org/kie/trustyai/service/data/readers/RandomReader.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/RandomReader.java
@@ -4,7 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.explainability.model.Feature;
+import org.kie.trustyai.explainability.model.FeatureFactory;
+import org.kie.trustyai.explainability.model.Output;
+import org.kie.trustyai.explainability.model.Prediction;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.explainability.model.SimplePrediction;
+import org.kie.trustyai.explainability.model.Type;
+import org.kie.trustyai.explainability.model.Value;
 
 public class RandomReader implements DataReader {
 

--- a/src/main/java/org/kie/trustyai/service/data/readers/utils/CSVUtils.java
+++ b/src/main/java/org/kie/trustyai/service/data/readers/utils/CSVUtils.java
@@ -10,7 +10,13 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.explainability.model.Feature;
+import org.kie.trustyai.explainability.model.FeatureFactory;
+import org.kie.trustyai.explainability.model.Output;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.explainability.model.Type;
+import org.kie.trustyai.explainability.model.Value;
 
 public class CSVUtils {
 

--- a/src/main/java/org/kie/trustyai/service/endpoints/explainers/LIMEEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/explainers/LIMEEndpoint.java
@@ -10,12 +10,17 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.kie.trustyai.connectors.kserve.v2.KServeV2GRPCPredictionProvider;
 import org.kie.trustyai.explainability.local.lime.LimeExplainer;
-import org.kie.trustyai.explainability.model.*;
+import org.kie.trustyai.explainability.model.FeatureFactory;
+import org.kie.trustyai.explainability.model.Prediction;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.explainability.model.PredictionProvider;
+import org.kie.trustyai.explainability.model.SaliencyResults;
+import org.kie.trustyai.explainability.model.SimplePrediction;
 import org.kie.trustyai.service.config.ServiceConfig;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 @Path("/lime")
 public class LIMEEndpoint {

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
@@ -1,37 +1,30 @@
 package org.kie.trustyai.service.endpoints.metrics;
 
-import java.util.List;
 import java.util.UUID;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.kie.trustyai.explainability.metrics.FairnessMetrics;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.Output;
-import org.kie.trustyai.explainability.model.Type;
-import org.kie.trustyai.explainability.model.Value;
-import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
 import org.kie.trustyai.service.data.readers.MinioReader;
 import org.kie.trustyai.service.data.readers.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.payloads.MetricThreshold;
-import org.kie.trustyai.service.payloads.PayloadConverter;
 import org.kie.trustyai.service.payloads.dir.DisparateImpactRationResponse;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
-import org.kie.trustyai.service.payloads.spd.DisparateImpactRatioScheduledRequests;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceScheduledResponse;
-import org.kie.trustyai.service.prometheus.PrometheusPublisher;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.quarkus.scheduler.Scheduled;
+import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 
 @Path("/metrics/dir")
 public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
@@ -41,34 +34,16 @@ public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
     MinioReader dataReader;
 
     @Inject
-    ServiceConfig serviceConfig;
-
-    @Inject
     MetricsConfig metricsConfig;
 
     @Inject
-    PrometheusPublisher publisher;
+    MetricsCalculator calculator;
 
     @Inject
-    DisparateImpactRatioScheduledRequests schedule;
+    PrometheusScheduler scheduler;
 
     DisparateImpactRatioEndpoint() {
         super();
-    }
-
-    private double calculate(Dataframe dataframe, GroupStatisticalParityDifferenceRequest request) {
-        final int protectedIndex = dataframe.getColumnNames().indexOf(request.getProtectedAttribute());
-
-        final Value privilegedAttr = PayloadConverter.convertToValue(request.getPrivilegedAttribute());
-
-        final Dataframe privileged = dataframe.filterByColumnValue(protectedIndex,
-                value -> value.equals(privilegedAttr));
-        final Value unprivilegedAttr = PayloadConverter.convertToValue(request.getUnprivilegedAttribute());
-        final Dataframe unprivileged = dataframe.filterByColumnValue(protectedIndex,
-                value -> value.equals(unprivilegedAttr));
-        final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
-        return FairnessMetrics.groupDisparateImpactRatio(privileged, unprivileged,
-                List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
     }
 
     @Override
@@ -83,9 +58,10 @@ public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
 
         final Dataframe df = dataReader.asDataframe();
 
-        final double dir = calculate(df, request);
+        final double dir = calculator.calculateDIR(df, request);
 
-        final MetricThreshold thresholds = new MetricThreshold(metricsConfig.dir().thresholdLower(), metricsConfig.dir().thresholdUpper(), dir);
+        final MetricThreshold thresholds =
+                new MetricThreshold(metricsConfig.dir().thresholdLower(), metricsConfig.dir().thresholdUpper(), dir);
         final DisparateImpactRationResponse dirObj = new DisparateImpactRationResponse(dir, thresholds);
 
         return Response.ok(dirObj).build();
@@ -97,17 +73,14 @@ public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
     @Path("/request")
     public String createRequest(GroupStatisticalParityDifferenceRequest request) throws JsonProcessingException {
 
-        final UUID requestId = UUID.randomUUID();
+        final UUID id = UUID.randomUUID();
 
-        schedule.getRequests().put(requestId, request);
+        scheduler.registerDIR(id, request);
 
         final GroupStatisticalParityDifferenceScheduledResponse response =
-                new GroupStatisticalParityDifferenceScheduledResponse(requestId);
-
-        calculate();
+                new GroupStatisticalParityDifferenceScheduledResponse(id);
 
         ObjectMapper mapper = new ObjectMapper();
-
         return mapper.writeValueAsString(response);
     }
 
@@ -119,30 +92,13 @@ public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
 
         final UUID id = request.requestId;
 
-        if (schedule.getRequests().containsKey(id)) {
-            schedule.getRequests().remove(request.requestId);
+        if (scheduler.getDirRequests().containsKey(id)) {
+            scheduler.getDirRequests().remove(request.requestId);
             LOG.info("Removing scheduled request id=" + id);
             return RestResponse.ResponseBuilder.ok("Removed").build().toResponse();
         } else {
             LOG.error("Scheduled request id=" + id + " not found");
             return RestResponse.ResponseBuilder.notFound().build().toResponse();
-        }
-    }
-
-    @Scheduled(every = "{SERVICE_METRICS_SCHEDULE}")
-    void calculate() {
-
-        try {
-            final Dataframe df = dataReader.asDataframe();
-            if (!schedule.getRequests().isEmpty()) {
-                schedule.getRequests().forEach((uuid, request) -> {
-
-                    final double dir = calculate(df, request);
-                    publisher.gaugeDIR(request, serviceConfig.modelName(), uuid, dir);
-                });
-            }
-        } catch (DataframeCreateException e) {
-            LOG.error(e.getMessage());
         }
     }
 

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/MetricsCalculator.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/MetricsCalculator.java
@@ -1,0 +1,47 @@
+package org.kie.trustyai.service.endpoints.metrics;
+
+import java.util.List;
+
+import javax.inject.Singleton;
+
+import org.kie.trustyai.explainability.metrics.FairnessMetrics;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.explainability.model.Output;
+import org.kie.trustyai.explainability.model.Type;
+import org.kie.trustyai.explainability.model.Value;
+import org.kie.trustyai.service.payloads.PayloadConverter;
+import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
+
+@Singleton
+public class MetricsCalculator {
+
+    public double calculateSPD(Dataframe dataframe, GroupStatisticalParityDifferenceRequest request) {
+        final int protectedIndex = dataframe.getColumnNames().indexOf(request.getProtectedAttribute());
+
+        final Value privilegedAttr = PayloadConverter.convertToValue(request.getPrivilegedAttribute());
+
+        final Dataframe privileged = dataframe.filterByColumnValue(protectedIndex,
+                value -> value.equals(privilegedAttr));
+        final Value unprivilegedAttr = PayloadConverter.convertToValue(request.getUnprivilegedAttribute());
+        final Dataframe unprivileged = dataframe.filterByColumnValue(protectedIndex,
+                value -> value.equals(unprivilegedAttr));
+        final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
+        return FairnessMetrics.groupStatisticalParityDifference(privileged, unprivileged,
+                List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
+    }
+
+    public double calculateDIR(Dataframe dataframe, GroupStatisticalParityDifferenceRequest request) {
+        final int protectedIndex = dataframe.getColumnNames().indexOf(request.getProtectedAttribute());
+
+        final Value privilegedAttr = PayloadConverter.convertToValue(request.getPrivilegedAttribute());
+
+        final Dataframe privileged = dataframe.filterByColumnValue(protectedIndex,
+                value -> value.equals(privilegedAttr));
+        final Value unprivilegedAttr = PayloadConverter.convertToValue(request.getUnprivilegedAttribute());
+        final Dataframe unprivileged = dataframe.filterByColumnValue(protectedIndex,
+                value -> value.equals(unprivilegedAttr));
+        final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
+        return FairnessMetrics.groupDisparateImpactRatio(privileged, unprivileged,
+                List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
+    }
+}

--- a/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/PayloadConverter.java
@@ -1,9 +1,8 @@
 package org.kie.trustyai.service.payloads;
 
-import org.kie.trustyai.explainability.model.Value;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import org.kie.trustyai.explainability.model.Value;
 
 public class PayloadConverter {
     public static Value convertToValue(JsonNode node) {

--- a/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
+++ b/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
@@ -6,15 +6,13 @@ import java.util.UUID;
 
 import javax.inject.Singleton;
 
-import org.jboss.logging.Logger;
-import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
-
 import com.google.common.util.concurrent.AtomicDouble;
-
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import org.jboss.logging.Logger;
+import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
 
 @Singleton
 public class PrometheusPublisher {


### PR DESCRIPTION
Scheduled metric calculation was being performed at each metric type separately.
This meant that for `n` metric types, the data was being read `n` times. e.g. (10 SPD Prometheus metrics and 5 DIR Prometheus metrics meant the data was being read twice).

Since the data used for all the metrics has the same source, the metrics are now calculated in a single method inside a `PrometheusScheduler` class. This means that now data is only read once, regardless of how many Prometheus metrics we calculate. Using the example above: first the data is read and then 10 SPD Prometheus metrics and 5 DIR Prometheus metrics are calculated from the same data.

Fixes #24 .