### PR TITLE
Add optional batch size to datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,17 +273,21 @@ trustyai_spd{
 
 ## Metrics
 
-Data source extend the base `AbstractDataReader` which has the responsibility
-of converting any type of data source (flat file on PVC, S3, database, _etc_) into a TrustyAI `Dataframe`.
+Storage backend adapters implement the `Storage` interface which has the responsibility
+of reading the data from a specific storage type (flat file on PVC, S3, database, _etc_)
+and return the inputs and outputs as `ByteBuffer`.
+From there, the service converts the `ByteBuffer` into a TrustyAI `Dataframe` to be used
+in the metrics calculations.
 
-The type of datasource is passed with the environment variable `STORAGE_FORMAT`.
-
-For demo purposes we abstract the data source to `SERVICE_STORAGE_FORMAT=RANDOM_TEST`
-which generates in memory new data points for each request.
+The type of datasource is passed with the environment variable `SERVICE_STORAGE_FORMAT`.
 
 The supported data sources are:
 
 - MinIO
+
+The data can be batched into the latest `n` observations by using the configuration key
+`SERVICE_BATCH_SIZE=n`. This behaves like a `n`-size tail and its optional.
+If not specified, the entire dataset is used.
 
 ## Explainers
 

--- a/demo/compose.yaml
+++ b/demo/compose.yaml
@@ -15,6 +15,7 @@ services:
       MINIO_SECRET_KEY: "minioadmin"
       MINIO_ACCESS_KEY: "minioadmin"
       SERVICE_METRICS_SCHEDULE: "5s"
+      SERVICE_BATCH_SIZE: 5000
   prometheus:
     image: prom/prometheus
     container_name: prometheus

--- a/src/main/java/org/kie/trustyai/service/config/ServiceConfig.java
+++ b/src/main/java/org/kie/trustyai/service/config/ServiceConfig.java
@@ -1,12 +1,15 @@
 package org.kie.trustyai.service.config;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithName;
 
 @ConfigMapping(prefix = "service", namingStrategy = ConfigMapping.NamingStrategy.KEBAB_CASE)
 public interface ServiceConfig {
+    
+    OptionalInt batchSize();
 
     String modelName();
 

--- a/src/main/java/org/kie/trustyai/service/data/DataParser.java
+++ b/src/main/java/org/kie/trustyai/service/data/DataParser.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -12,6 +14,7 @@ import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
 import org.kie.trustyai.service.data.storage.MinioStorage;
@@ -22,6 +25,8 @@ public class DataParser {
     private static final Logger LOG = Logger.getLogger(DataParser.class);
     private static final Charset UTF8 = StandardCharsets.UTF_8;
     @Inject MinioStorage storage;
+
+    @Inject ServiceConfig serviceConfig;
 
     public Dataframe getDataframe() throws DataframeCreateException {
 
@@ -55,7 +60,25 @@ public class DataParser {
             throw new DataframeCreateException(e.getMessage());
         }
 
-        return Dataframe.createFrom(predictionInputs, predictionOutputs);
+        final Dataframe dataframe = Dataframe.createFrom(predictionInputs, predictionOutputs);
+        if (serviceConfig.batchSize().isPresent()) {
+            final int batchSize = serviceConfig.batchSize().getAsInt();
+            final int rows = dataframe.getRowDimension();
+
+            if (batchSize >= rows) {
+                LOG.info("Batching with " + batchSize + " rows. Passing " + dataframe.getRowDimension() + " rows");
+                return dataframe;
+            } else {
+                final List<Integer> indices = IntStream.range(rows - batchSize, rows).boxed().collect(Collectors.toList());
+                final Dataframe batch = dataframe.filterByRowIndex(indices);
+                LOG.info("Batching with " + batchSize + " rows. Passing " + batch.getRowDimension() + " rows");
+                return batch;
+            }
+        } else {
+            LOG.info("No batching. Passing all of " + dataframe.getRowDimension() + " rows");
+            return dataframe;
+
+        }
     }
 
 }


### PR DESCRIPTION
An optional configuration option is added `SERVICE_BATCH_SIZE=n`, which works as a `n`-sized tail for data.
This is optional, and if not specified, the entire dataset is used.

Closes #11 .