### PR TITLE
Metric Definitions: Added metric definitions endpoints + reponse bodies

### DIFF
--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
@@ -5,30 +5,37 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
+import org.kie.trustyai.explainability.metrics.FairnessMetrics;
+import org.kie.trustyai.explainability.metrics.utils.FairnessDefinitions;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
 import org.kie.trustyai.service.data.DataParser;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.payloads.MetricThreshold;
-import org.kie.trustyai.service.payloads.dir.DisparateImpactRationResponse;
+import org.kie.trustyai.service.payloads.dir.DisparateImpactRatioResponse;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceScheduledResponse;
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 
+@Tag(name = "Disparate Impact Ratio Endpoint", description =  "Disparate Impact Ratio (DIR) measures imbalances in " +
+        "classifications by calculating the ratio between the proportion of the majority and protected classes getting" +
+        " a particular outcome.")
 @Path("/metrics/dir")
 public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
-
     private static final Logger LOG = Logger.getLogger(DisparateImpactRatioEndpoint.class);
     @Inject
     DataParser dataParser;
@@ -59,13 +66,22 @@ public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
         final Dataframe df = dataParser.getDataframe();
 
         final double dir = calculator.calculateDIR(df, request);
+        final String dirDefinition = calculator.getDIRDefinition(dir, request);
 
         final MetricThreshold thresholds =
                 new MetricThreshold(metricsConfig.dir().thresholdLower(), metricsConfig.dir().thresholdUpper(), dir);
-        final DisparateImpactRationResponse dirObj = new DisparateImpactRationResponse(dir, thresholds);
+        final DisparateImpactRatioResponse dirObj = new DisparateImpactRatioResponse(dir, dirDefinition, thresholds);
 
         return Response.ok(dirObj).build();
     }
+
+    @GET
+    @Path("/definition")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getDefinition() {
+        return Response.ok(FairnessDefinitions.defineGroupDisparateImpactRatio()).build();
+    }
+
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -5,16 +5,21 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
+import org.kie.trustyai.explainability.metrics.FairnessMetrics;
+import org.kie.trustyai.explainability.metrics.utils.FairnessDefinitions;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
 import org.kie.trustyai.service.data.DataParser;
@@ -26,6 +31,8 @@ import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRes
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceScheduledResponse;
 import org.kie.trustyai.service.prometheus.PrometheusScheduler;
 
+@Tag(name = "Statistical Parity Difference Endpoint", description =  "Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the " +
+        "difference between the proportion of the majority and protected classes getting a particular outcome.")
 @Path("/metrics/spd")
 public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEndpoint {
 
@@ -59,14 +66,23 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
         final Dataframe df = dataParser.getDataframe();
 
         final double spd = calculator.calculateSPD(df, request);
+        final String definition = calculator.getSPDDefinition(spd, request);
 
         final MetricThreshold thresholds = new MetricThreshold(
                 metricsConfig.spd().thresholdLower(),
                 metricsConfig.spd().thresholdUpper(), spd);
-        final GroupStatisticalParityDifferenceResponse spdObj = new GroupStatisticalParityDifferenceResponse(spd, thresholds);
+        final GroupStatisticalParityDifferenceResponse spdObj = new GroupStatisticalParityDifferenceResponse(spd, definition, thresholds);
 
         return Response.ok(spdObj).build();
     }
+
+    @GET
+    @Path("/definition")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getDefinition() {
+        return Response.ok(FairnessDefinitions.defineGroupStatisticalParityDifference()).build();
+    }
+
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/MetricsCalculator.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/MetricsCalculator.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.inject.Singleton;
 
 import org.kie.trustyai.explainability.metrics.FairnessMetrics;
+import org.kie.trustyai.explainability.metrics.utils.FairnessDefinitions;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.Output;
 import org.kie.trustyai.explainability.model.Type;
@@ -30,6 +31,21 @@ public class MetricsCalculator {
                 List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
     }
 
+    public String getSPDDefinition(double spd, GroupStatisticalParityDifferenceRequest request) {
+        final String outcomeName = request.getOutcomeName();
+        final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
+        final String protectedAttribute = request.getProtectedAttribute();
+        final String priviliged = PayloadConverter.convertToValue(request.getPrivilegedAttribute()).toString();
+        final String unpriviliged = PayloadConverter.convertToValue(request.getUnprivilegedAttribute()).toString();
+        return FairnessDefinitions.defineGroupStatisticalParityDifference(
+                protectedAttribute,
+                priviliged,
+                unpriviliged,
+                outcomeName,
+                favorableOutcomeAttr,
+                spd);
+    }
+
     public double calculateDIR(Dataframe dataframe, GroupStatisticalParityDifferenceRequest request) {
         final int protectedIndex = dataframe.getColumnNames().indexOf(request.getProtectedAttribute());
 
@@ -43,5 +59,20 @@ public class MetricsCalculator {
         final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
         return FairnessMetrics.groupDisparateImpactRatio(privileged, unprivileged,
                 List.of(new Output(request.getOutcomeName(), Type.NUMBER, favorableOutcomeAttr, 1.0)));
+    }
+
+    public String getDIRDefinition(double dir, GroupStatisticalParityDifferenceRequest request) {
+        final String outcomeName = request.getOutcomeName();
+        final Value favorableOutcomeAttr = PayloadConverter.convertToValue(request.getFavorableOutcome());
+        final String protectedAttribute = request.getProtectedAttribute();
+        final String priviliged = PayloadConverter.convertToValue(request.getPrivilegedAttribute()).toString();
+        final String unpriviliged = PayloadConverter.convertToValue(request.getUnprivilegedAttribute()).toString();
+        return FairnessDefinitions.defineGroupDisparateImpactRatio(
+                protectedAttribute,
+                priviliged,
+                unpriviliged,
+                outcomeName,
+                favorableOutcomeAttr,
+                dir);
     }
 }

--- a/src/main/java/org/kie/trustyai/service/payloads/BaseMetricResponse.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/BaseMetricResponse.java
@@ -7,12 +7,14 @@ public abstract class BaseMetricResponse {
     public String type = "metric";
     public String name;
     public Double value;
+    public String specificDefinition;
     public UUID id;
     public Date timestamp = new Date();
 
-    public BaseMetricResponse(Double value) {
+    public BaseMetricResponse(Double value, String specificDefinition) {
         this.value = value;
         this.id = UUID.randomUUID();
+        this.specificDefinition = specificDefinition;
     }
 
 }

--- a/src/main/java/org/kie/trustyai/service/payloads/dir/DisparateImpactRatioResponse.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/dir/DisparateImpactRatioResponse.java
@@ -1,16 +1,17 @@
 package org.kie.trustyai.service.payloads.dir;
 
+import org.kie.trustyai.explainability.metrics.FairnessMetrics;
 import org.kie.trustyai.service.payloads.BaseMetricResponse;
 import org.kie.trustyai.service.payloads.MetricThreshold;
 
-public class DisparateImpactRationResponse extends BaseMetricResponse {
+public class DisparateImpactRatioResponse extends BaseMetricResponse {
 
     public String name = "DIR";
 
     public MetricThreshold thresholds;
 
-    public DisparateImpactRationResponse(Double value, MetricThreshold threshold) {
-        super(value);
+    public DisparateImpactRatioResponse(Double value, String specificDefinition, MetricThreshold threshold) {
+        super(value, specificDefinition);
         this.thresholds = threshold;
     }
 }

--- a/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceResponse.java
+++ b/src/main/java/org/kie/trustyai/service/payloads/spd/GroupStatisticalParityDifferenceResponse.java
@@ -1,5 +1,6 @@
 package org.kie.trustyai.service.payloads.spd;
 
+import org.kie.trustyai.explainability.metrics.FairnessMetrics;
 import org.kie.trustyai.service.payloads.BaseMetricResponse;
 import org.kie.trustyai.service.payloads.MetricThreshold;
 
@@ -8,8 +9,8 @@ public class GroupStatisticalParityDifferenceResponse extends BaseMetricResponse
     public String name = "SPD";
     public MetricThreshold thresholds;
 
-    public GroupStatisticalParityDifferenceResponse(Double value, MetricThreshold thresholds) {
-        super(value);
+    public GroupStatisticalParityDifferenceResponse(Double value, String specificDefinition, MetricThreshold thresholds) {
+        super(value, specificDefinition);
         this.thresholds = thresholds;
     }
 }


### PR DESCRIPTION
1) The OpenAPI specification now has short metric descriptions in the tags:

```
openapi: 3.0.3
info:
  title: trustyai-service API
  version: 1.0.0-SNAPSHOT
tags:
- name: Disparate Impact Ratio Endpoint
  description: Disparate Impact Ratio (DIR) measures imbalances in classifications
    by calculating the ratio between the proportion of the majority and protected
    classes getting a particular outcome.
- name: Statistical Parity Difference Endpoint
  description: Statistical Parity Difference (SPD) measures imbalances in classifications
    by calculating the difference between the proportion of the majority and protected
    classes getting a particular outcome.
```
    
2) General metric definitions can be queried by:
`curl -X GET http://localhost:8080/metrics/spd/definition`
returns
`
Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the difference between the proportion of the majority and protected classes getting a particular outcome. Typically, -0.1 < SPD < 0.1 indicates a fair model, while a value outside those bounds indicates an unfair model for the groups and outcomes in question.
`

3) Specific metric descriptions are returned in metric query bodies:
```
curl -X POST --location "http://localhost:8080/metrics/dir/" \
    -H "Content-Type: application/json" \
    -d "{
          \"protectedAttribute\": \"gender\",
          \"favorableOutcome\": 1,
          \"outcomeName\": \"income\",
          \"privilegedAttribute\": 1,
          \"unprivilegedAttribute\": 0
        }"
```
returns
`
{"type":"metric","name":"DIR","value":0.17292587250695893,"specificDefinition":"The DIR of 0.172926 indicates that the likelihood of Group:gender=1 receiving Outcome:income=1 is 0.172926 times that of Group:gender=0.","id":"2b3e009a-ddf7-496e-843d-812893c3a478","timestamp":"2023-02-13T13:42:03.448+00:00","thresholds":{"lowerBound":0.8,"upperBound":1.2,"outsideBounds":true}}
`     

