### PR TITLE
Decouple parser and storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and run the container using (either `docker`, `podman`):
 
 ```shell
 docker run -p 8080:8080 \
-    --env SERVICE_STORAGE_FORMAT=CSV \
+    --env SERVICE_DATA_FORMAT=CSV \
     --env SERVICE_MODEL_NAME=example \
     --env SERVICE_STORAGE_FORMAT="MINIO" \
     --env MINIO_BUCKET_NAME="inputs" \

--- a/demo/compose.yaml
+++ b/demo/compose.yaml
@@ -8,6 +8,7 @@ services:
       SERVICE_MODEL_NAME: "example"
       SERVICE_KSERVE_TARGET: "localhost"
       SERVICE_STORAGE_FORMAT: "MINIO"
+      SERVICE_DATA_FORMAT: "CSV"
       MINIO_BUCKET_NAME: "inputs"
       MINIO_ENDPOINT: "http://minio:9000"
       MINIO_INPUT_FILENAME: "income-biased-inputs.csv"

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>3.0.5</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,19 +89,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.smallrye</groupId>
-        <artifactId>jandex-maven-plugin</artifactId>
-        <version>3.0.5</version>
-        <executions>
-          <execution>
-            <id>make-index</id>
-            <goals>
-              <goal>jandex</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/src/main/java/org/kie/trustyai/service/config/ServiceConfig.java
+++ b/src/main/java/org/kie/trustyai/service/config/ServiceConfig.java
@@ -18,5 +18,8 @@ public interface ServiceConfig {
 
     String storageFormat();
 
+    String dataFormat();
+
     String metricsSchedule();
+
 }

--- a/src/main/java/org/kie/trustyai/service/data/DataSource.java
+++ b/src/main/java/org/kie/trustyai/service/data/DataSource.java
@@ -1,40 +1,31 @@
 package org.kie.trustyai.service.data;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.quarkus.arc.DefaultBean;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
-import org.kie.trustyai.explainability.model.PredictionInput;
-import org.kie.trustyai.explainability.model.PredictionOutput;
 import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
 import org.kie.trustyai.service.data.parsers.DataParser;
-import org.kie.trustyai.service.data.storage.MinioStorage;
 import org.kie.trustyai.service.data.storage.Storage;
-import org.kie.trustyai.service.data.utils.CSVUtils;
 
 @Singleton
 public class DataSource {
     private static final Logger LOG = Logger.getLogger(DataSource.class);
 
     @Inject
-    Instance<Storage> storage;
+    Storage storage;
 
     @Inject
-    Instance<DataParser> parser;
+    DataParser parser;
 
     @Inject ServiceConfig serviceConfig;
 
@@ -42,19 +33,19 @@ public class DataSource {
 
         final ByteBuffer inputsBuffer;
         try {
-             inputsBuffer = storage.get().getInputData();
+             inputsBuffer = storage.getInputData();
         } catch (StorageReadException e) {
             throw new DataframeCreateException(e.getMessage());
         }
 
         final ByteBuffer outputsBuffer;
         try {
-            outputsBuffer = storage.get().getOutputData();
+            outputsBuffer = storage.getOutputData();
         } catch (StorageReadException e) {
             throw new DataframeCreateException(e.getMessage());
         }
 
-        final Dataframe dataframe = parser.get().parse(inputsBuffer, outputsBuffer);
+        final Dataframe dataframe = parser.parse(inputsBuffer, outputsBuffer);
         if (serviceConfig.batchSize().isPresent()) {
             final int batchSize = serviceConfig.batchSize().getAsInt();
             final int rows = dataframe.getRowDimension();

--- a/src/main/java/org/kie/trustyai/service/data/DataSource.java
+++ b/src/main/java/org/kie/trustyai/service/data/DataSource.java
@@ -1,15 +1,19 @@
 package org.kie.trustyai.service.data;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import io.quarkus.arc.DefaultBean;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.explainability.model.PredictionInput;
@@ -17,50 +21,40 @@ import org.kie.trustyai.explainability.model.PredictionOutput;
 import org.kie.trustyai.service.config.ServiceConfig;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
+import org.kie.trustyai.service.data.parsers.DataParser;
 import org.kie.trustyai.service.data.storage.MinioStorage;
+import org.kie.trustyai.service.data.storage.Storage;
 import org.kie.trustyai.service.data.utils.CSVUtils;
 
 @Singleton
-public class DataParser {
-    private static final Logger LOG = Logger.getLogger(DataParser.class);
-    private static final Charset UTF8 = StandardCharsets.UTF_8;
-    @Inject MinioStorage storage;
+public class DataSource {
+    private static final Logger LOG = Logger.getLogger(DataSource.class);
+
+    @Inject
+    Instance<Storage> storage;
+
+    @Inject
+    Instance<DataParser> parser;
 
     @Inject ServiceConfig serviceConfig;
 
     public Dataframe getDataframe() throws DataframeCreateException {
 
-        final String inputData;
+        final ByteBuffer inputsBuffer;
         try {
-            inputData = UTF8.decode(storage.getInputData()).toString();
+             inputsBuffer = storage.get().getInputData();
         } catch (StorageReadException e) {
-            LOG.error(e.getMessage());
             throw new DataframeCreateException(e.getMessage());
         }
 
-        final String outputData;
+        final ByteBuffer outputsBuffer;
         try {
-            outputData = UTF8.decode(storage.getOutputData()).toString();
+            outputsBuffer = storage.get().getOutputData();
         } catch (StorageReadException e) {
-            LOG.error(e.getMessage());
             throw new DataframeCreateException(e.getMessage());
         }
 
-        final List<PredictionInput> predictionInputs;
-        try {
-            predictionInputs = CSVUtils.parseInputs(inputData);
-        } catch (IOException e) {
-            throw new DataframeCreateException(e.getMessage());
-        }
-
-        final List<PredictionOutput> predictionOutputs;
-        try {
-            predictionOutputs = CSVUtils.parseOutputs(outputData);
-        } catch (IOException e) {
-            throw new DataframeCreateException(e.getMessage());
-        }
-
-        final Dataframe dataframe = Dataframe.createFrom(predictionInputs, predictionOutputs);
+        final Dataframe dataframe = parser.get().parse(inputsBuffer, outputsBuffer);
         if (serviceConfig.batchSize().isPresent()) {
             final int batchSize = serviceConfig.batchSize().getAsInt();
             final int rows = dataframe.getRowDimension();
@@ -79,6 +73,9 @@ public class DataParser {
             return dataframe;
 
         }
+
+
     }
+
 
 }

--- a/src/main/java/org/kie/trustyai/service/data/parsers/CSVParser.java
+++ b/src/main/java/org/kie/trustyai/service/data/parsers/CSVParser.java
@@ -1,0 +1,47 @@
+package org.kie.trustyai.service.data.parsers;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import org.jboss.logging.Logger;
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.explainability.model.PredictionInput;
+import org.kie.trustyai.explainability.model.PredictionOutput;
+import org.kie.trustyai.service.data.DataSource;
+import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+import org.kie.trustyai.service.data.exceptions.StorageReadException;
+import org.kie.trustyai.service.data.utils.CSVUtils;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@LookupIfProperty(name="service.data.format", stringValue = "CSV")
+@ApplicationScoped
+public class CSVParser implements DataParser {
+    private static final Logger LOG = Logger.getLogger(CSVParser.class);
+    private static final Charset UTF8 = StandardCharsets.UTF_8;
+
+    @Override
+    public Dataframe parse(ByteBuffer inputs, ByteBuffer outputs) throws DataframeCreateException {
+        final String inputData = UTF8.decode(inputs).toString();
+        final String outputData = UTF8.decode(outputs).toString();
+
+        final List<PredictionInput> predictionInputs;
+        try {
+            predictionInputs = CSVUtils.parseInputs(inputData);
+        } catch (IOException e) {
+            throw new DataframeCreateException(e.getMessage());
+        }
+
+        final List<PredictionOutput> predictionOutputs;
+        try {
+            predictionOutputs = CSVUtils.parseOutputs(outputData);
+        } catch (IOException e) {
+            throw new DataframeCreateException(e.getMessage());
+        }
+        LOG.info("Creating dataframe from CSV data");
+        return Dataframe.createFrom(predictionInputs, predictionOutputs);
+    }
+}

--- a/src/main/java/org/kie/trustyai/service/data/parsers/DataParser.java
+++ b/src/main/java/org/kie/trustyai/service/data/parsers/DataParser.java
@@ -1,0 +1,11 @@
+package org.kie.trustyai.service.data.parsers;
+
+import org.kie.trustyai.explainability.model.Dataframe;
+import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
+
+import java.nio.ByteBuffer;
+
+public interface DataParser {
+
+    Dataframe parse(ByteBuffer inputs, ByteBuffer outputs) throws DataframeCreateException;
+}

--- a/src/main/java/org/kie/trustyai/service/data/storage/MinioStorage.java
+++ b/src/main/java/org/kie/trustyai/service/data/storage/MinioStorage.java
@@ -5,6 +5,8 @@ import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import io.minio.GetObjectArgs;
@@ -18,11 +20,13 @@ import io.minio.errors.InvalidResponseException;
 import io.minio.errors.MinioException;
 import io.minio.errors.ServerException;
 import io.minio.errors.XmlParserException;
+import io.quarkus.arc.lookup.LookupIfProperty;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.service.config.readers.MinioConfig;
 import org.kie.trustyai.service.data.exceptions.StorageReadException;
 
-@Singleton
+@LookupIfProperty(name="service.storage.format", stringValue = "MINIO")
+@ApplicationScoped
 public class MinioStorage implements Storage {
 
     private static final Logger LOG = Logger.getLogger(MinioStorage.class);

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/DisparateImpactRatioEndpoint.java
@@ -17,7 +17,7 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
-import org.kie.trustyai.service.data.DataParser;
+import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.payloads.MetricThreshold;
 import org.kie.trustyai.service.payloads.dir.DisparateImpactRationResponse;
@@ -31,7 +31,7 @@ public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
 
     private static final Logger LOG = Logger.getLogger(DisparateImpactRatioEndpoint.class);
     @Inject
-    DataParser dataParser;
+    DataSource dataSource;
 
     @Inject
     MetricsConfig metricsConfig;
@@ -56,7 +56,7 @@ public class DisparateImpactRatioEndpoint extends AbstractMetricsEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Response dir(GroupStatisticalParityDifferenceRequest request) throws DataframeCreateException {
 
-        final Dataframe df = dataParser.getDataframe();
+        final Dataframe df = dataSource.getDataframe();
 
         final double dir = calculator.calculateDIR(df, request);
 

--- a/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
+++ b/src/main/java/org/kie/trustyai/service/endpoints/metrics/GroupStatisticalParityDifferenceEndpoint.java
@@ -17,7 +17,7 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.metrics.MetricsConfig;
-import org.kie.trustyai.service.data.DataParser;
+import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.payloads.MetricThreshold;
 import org.kie.trustyai.service.payloads.scheduler.ScheduleId;
@@ -31,7 +31,7 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
 
     private static final Logger LOG = Logger.getLogger(GroupStatisticalParityDifferenceEndpoint.class);
     @Inject
-    DataParser dataParser;
+    DataSource dataSource;
 
     @Inject
     PrometheusScheduler scheduler;
@@ -56,7 +56,7 @@ public class GroupStatisticalParityDifferenceEndpoint extends AbstractMetricsEnd
     @Produces(MediaType.APPLICATION_JSON)
     public Response spd(GroupStatisticalParityDifferenceRequest request) throws DataframeCreateException {
 
-        final Dataframe df = dataParser.getDataframe();
+        final Dataframe df = dataSource.getDataframe();
 
         final double spd = calculator.calculateSPD(df, request);
 

--- a/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -11,7 +11,7 @@ import io.quarkus.scheduler.Scheduled;
 import org.jboss.logging.Logger;
 import org.kie.trustyai.explainability.model.Dataframe;
 import org.kie.trustyai.service.config.ServiceConfig;
-import org.kie.trustyai.service.data.DataParser;
+import org.kie.trustyai.service.data.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.endpoints.metrics.MetricsCalculator;
 import org.kie.trustyai.service.payloads.spd.GroupStatisticalParityDifferenceRequest;
@@ -23,7 +23,7 @@ public class PrometheusScheduler {
     private final Map<UUID, GroupStatisticalParityDifferenceRequest> spdRequests = new HashMap<>();
     private final Map<UUID, GroupStatisticalParityDifferenceRequest> dirRequests = new HashMap<>();
     @Inject
-    DataParser dataParser;
+    DataSource dataSource;
     @Inject
     PrometheusPublisher publisher;
     @Inject
@@ -43,7 +43,7 @@ public class PrometheusScheduler {
 
         if (hasRequests()) {
             try {
-                final Dataframe df = dataParser.getDataframe();
+                final Dataframe df = dataSource.getDataframe();
 
                 // SPD requests
                 if (!spdRequests.isEmpty()) {


### PR DESCRIPTION
At the moment the parsing of data (read from an abstract `Storage`) was done in the data provider.

This PR adds a new abstraction `DataParser` in which new data formats can be implemented.
This allows combinations of storage and data (e.g. JSON in MinIO or CSV in PVC) to be implemented separately as a new format will be available for all storage types.

See #29 .